### PR TITLE
Add CadenzaBot assistant script

### DIFF
--- a/CadenzaBot.md
+++ b/CadenzaBot.md
@@ -1,0 +1,20 @@
+# CadenzaBot
+
+CadenzaBot is a small GPT-based assistant intended to help musicians using CadenzaBoard. The bot answers questions about the platform, gives tips for submitting work, and suggests ways to connect with mentors or improve practice routines.
+
+The included `cadenzabot.py` script provides a basic command-line interface. It requires an OpenAI API key and uses the `gpt-3.5-turbo` model by default.
+
+## Setup
+1. Install the OpenAI Python package:
+   ```bash
+   pip install openai
+   ```
+2. Set the `OPENAI_API_KEY` environment variable to your OpenAI key.
+3. Run the bot:
+   ```bash
+   python cadenzabot.py
+   ```
+
+When prompted, enter your questions or requests about using CadenzaBoard. Type `quit` to exit.
+
+The system prompt used by the script defines CadenzaBot's role and ensures responses stay focused on helping musicians navigate the platform.

--- a/cadenzabot.py
+++ b/cadenzabot.py
@@ -1,0 +1,39 @@
+import os
+import openai
+
+# Load your OpenAI API key from the environment or replace with your key
+openai.api_key = os.getenv('OPENAI_API_KEY', 'YOUR_OPENAI_API_KEY')
+
+SYSTEM_PROMPT = (
+    "You are CadenzaBot, a helpful assistant for the CadenzaBoard project. "
+    "CadenzaBoard is a platform where musicians showcase portfolios, receive feedback, "
+    "connect with mentors, and track their growth. You answer questions about how to "
+    "use the platform, suggest best practices for submissions, and offer encouragement "
+    "to emerging artists."
+)
+
+
+def chat_with_cadenzabot(messages):
+    """Send a conversation to the OpenAI ChatCompletion API and return the reply."""
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "system", "content": SYSTEM_PROMPT}] + messages,
+    )
+    return response['choices'][0]['message']['content']
+
+
+def main():
+    print("Welcome to CadenzaBot! Type 'quit' to exit.")
+    conversation = []
+    while True:
+        user_input = input('You: ')
+        if user_input.lower() in {'quit', 'exit'}:
+            break
+        conversation.append({"role": "user", "content": user_input})
+        reply = chat_with_cadenzabot(conversation)
+        print(f'CadenzaBot: {reply}')
+        conversation.append({"role": "assistant", "content": reply})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple script `cadenzabot.py` that calls OpenAI chat completion with a CadenzaBoard-focused system prompt
- document the bot usage and setup in `CadenzaBot.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6854ef558fa08332a43a1e75c7c59c42